### PR TITLE
Match Keras version 2.1.5+

### DIFF
--- a/keras/weightnorm.py
+++ b/keras/weightnorm.py
@@ -4,7 +4,7 @@ import tensorflow as tf
 
 # adapted from keras.optimizers.SGD
 class SGDWithWeightnorm(SGD):
-    def get_updates(self, params, constraints, loss):
+    def get_updates(self, params, loss):
         grads = self.get_gradients(loss, params)
         self.updates = []
 
@@ -47,9 +47,8 @@ class SGDWithWeightnorm(SGD):
                     new_V_param = V + v_v
 
                 # if there are constraints we apply them to V, not W
-                if p in constraints:
-                    c = constraints[p]
-                    new_V_param = c(new_V_param)
+                if getattr(p, 'constraint', None) is not None:
+                    new_V_param = p.constraint(new_V_param)
 
                 # wn param updates --> W updates
                 add_weightnorm_param_updates(self.updates, new_V_param, new_g_param, p, V_scaler)
@@ -64,16 +63,15 @@ class SGDWithWeightnorm(SGD):
                     new_p = p + v
 
                 # apply constraints
-                if p in constraints:
-                    c = constraints[p]
-                    new_p = c(new_p)
+                if getattr(p, 'constraint', None) is not None:
+                    new_p = p.constraint(new_p)
 
                 self.updates.append(K.update(p, new_p))
         return self.updates
 
 # adapted from keras.optimizers.Adam
 class AdamWithWeightnorm(Adam):
-    def get_updates(self, params, constraints, loss):
+    def get_updates(self, params, loss):
         grads = self.get_gradients(loss, params)
         self.updates = [K.update_add(self.iterations, 1)]
 
@@ -81,7 +79,7 @@ class AdamWithWeightnorm(Adam):
         if self.initial_decay > 0:
             lr *= (1. / (1. + self.decay * self.iterations))
 
-        t = self.iterations + 1
+        t = K.cast(self.iterations + 1, 'float32')
         lr_t = lr * K.sqrt(1. - K.pow(self.beta_2, t)) / (1. - K.pow(self.beta_1, t))
 
         shapes = [K.get_variable_shape(p) for p in params]
@@ -119,9 +117,8 @@ class AdamWithWeightnorm(Adam):
                 self.updates.append(K.update(v, v_t))
 
                 # if there are constraints we apply them to V, not W
-                if p in constraints:
-                    c = constraints[p]
-                    new_V_param = c(new_V_param)
+                if getattr(p, 'constraint', None) is not None:
+                    new_V_param = p.constraint(new_V_param)
 
                 # wn param updates --> W updates
                 add_weightnorm_param_updates(self.updates, new_V_param, new_g_param, p, V_scaler)
@@ -136,9 +133,9 @@ class AdamWithWeightnorm(Adam):
 
                 new_p = p_t
                 # apply constraints
-                if p in constraints:
-                    c = constraints[p]
-                    new_p = c(new_p)
+                if getattr(p, 'constraint', None) is not None:
+                    new_p = p.constraint(new_p)
+                
                 self.updates.append(K.update(p, new_p))
         return self.updates
 


### PR DESCRIPTION
Hi, 

Because Keras 2.1.5 has no "constraints" parameter in get_updates().
So I update get_updates() method to match Keras version 2.1.5+.
And I changed line:84 to

```
t = K.cast(self.iterations + 1, 'float32')
```

I don't know why Tensorflow installed on my computer keeps complaining:

```
TypeError: Input 'y' of 'Pow' Op has type int64 that does not match type float32 of argument 'x'.
```

Cheers, peter0749